### PR TITLE
Introducing a place for script examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ Options:
                                                                [default: "info"]
   -w, --disable-watch      disable file watching (don't exit process on file
                            changes)                             [default: false]
+  --disable-lwt            disable last-will-and-testament (usefull if the
+                           remote broker is read-only)          [default: false]
   -l, --latitude                                              [default: 48.7408]
   -m, --longitude                                              [default: 9.1778]                                            
 </pre>

--- a/config.js
+++ b/config.js
@@ -9,6 +9,7 @@ const config = require('yargs')
     .describe('help', 'show help')
     .describe('dir', 'directory to scan for .js and .coffee files. can be used multiple times.')
     .describe('disable-watch', 'disable file watching (don\'t exit process on file changes)')
+    .describe('disable-lwt', 'disable last-will-and-testament (usefull if the remote broker is read-only)')
     .alias({
         c: 'config',
         d: 'dir',
@@ -21,7 +22,6 @@ const config = require('yargs')
         u: 'url',
         v: 'verbosity',
         w: 'disable-watch'
-
     })
     .default({
         url: 'mqtt://127.0.0.1',
@@ -31,7 +31,8 @@ const config = require('yargs')
         'variable-prefix': 'var',
         verbosity: 'info',
         'disable-variables': false,
-        'disable-watch': false
+        'disable-watch': false,
+        'disable-lwt': false
     })
     .config('config')
     .version()

--- a/index.js
+++ b/index.js
@@ -117,8 +117,17 @@ function sunScheduleEvent(obj, shift) {
 }
 
 // MQTT
-const mqtt = modules.mqtt.connect(config.url, {will: {topic: config.name + '/connected', payload: '0', retain: true}});
-mqtt.publish(config.name + '/connected', '2', {retain: true});
+function connect(config) {
+    var mqtt;
+    if (config.disableLwt) {
+        mqtt = modules.mqtt.connect(config.url);
+    } else {
+        mqtt = modules.mqtt.connect(config.url, {will: {topic: config.name + '/connected', payload: '0', retain: true}});
+        mqtt.publish(config.name + '/connected', '2', {retain: true});
+    }
+    return mqtt;
+}
+const mqtt = connect(config);
 
 let firstConnect = true;
 let startTimeout;


### PR DESCRIPTION
Hello,
after some initial problems (hanging at startup if mqtt server is unreachable, figure out how to pass user/password, figure out how to retain variables), I got it to work and I really like the tool. It allows to fill the gap between what comes from a device and what one needs to properly handle the data.

A great thing would be place where people can share script examples. What would you think about an "examples" folder where people can add their use-cases vie pull requests?

As a starter, have added mine in this PR.

Best regards,
Michael.
